### PR TITLE
Fix wrong B octave in tuning definition

### DIFF
--- a/app/src/main/java/com/github/cythara/tuning/OudStdTurkishTuning.java
+++ b/app/src/main/java/com/github/cythara/tuning/OudStdTurkishTuning.java
@@ -22,7 +22,7 @@ public class OudStdTurkishTuning implements Tuning {
 
         C2_SHARP(C, 2, "#"),
         F2_SHARP(F, 2, "#"),
-        B3(B, 3),
+        B2(B, 2),
         E3(E, 3),
         A3(A, 3),
         D4(D, 4);


### PR DESCRIPTION
Hi,

I  tried the app and I realized that I made a mistake in the tuning definition. Here is the fix.

Sorry for the extra work.